### PR TITLE
Use `f64` for vertex type

### DIFF
--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -24,7 +24,7 @@ pub struct TriangleMesh {
 /// A vertex in a triangle mesh
 ///
 /// See [`TriangleMesh`].
-pub type Vertex = [f32; 3];
+pub type Vertex = [f64; 3];
 
 /// A triangle in a triangle mesh
 ///


### PR DESCRIPTION
3MF supports arbitrary precision through its string representation of
number types. It seems limiting to use an `f32` to represent that here,
and I see little reason to do that in this library.