### PR TITLE
Remove bzip2 dependency for wasm32 arch.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["encoding", "rendering::data-formats"]
 readme = "README.md"
 repository = "https://github.com/hannobraun/3mf-rs"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+zip = { version = "0.5.13", default-features = false, features = ["deflate"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+zip = "0.5.13"
 
 [dependencies]
 thiserror = "1.0.30"
-zip = "0.5.13"


### PR DESCRIPTION
This PR removes the bzip2 feature from the `zip` crate on wasm32 allowing it to build on this architecture.

This is being done as part of my effort to get fornjot working on wasm32.