### PR TITLE
Remove bzip2 support on all platforms.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ repository = "https://github.com/hannobraun/3mf-rs"
 
 [dependencies]
 thiserror = "1.0.30"
-zip = { version = "0.5.13", default-features = false }
+zip = { version = "0.5.13", default-features = false, features = ["deflate"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,6 @@ categories = ["encoding", "rendering::data-formats"]
 readme = "README.md"
 repository = "https://github.com/hannobraun/3mf-rs"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-zip = { version = "0.5.13", default-features = false, features = ["deflate"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-zip = "0.5.13"
-
 [dependencies]
 thiserror = "1.0.30"
+zip = { version = "0.5.13", default-features = false }


### PR DESCRIPTION
Removes compression support from the `zip` dependency.
Discussion for this is in #12.