### PR TITLE
Serde writing of 3mf Model XML

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ repository = "https://github.com/hannobraun/3mf-rs"
 
 
 [dependencies]
+quick-xml = { version = "0.27.1", features = ["serialize"] }
+serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.31"
 
 [dependencies.zip]

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,4 +11,12 @@ pub enum Error {
     /// Error writing ZIP file (3MF files are ZIP files)
     #[error("Error writing ZIP file (3MF files are ZIP files)")]
     Zip(#[from] ZipError),
+
+    /// Error reading/writing XML
+    #[error("Error reading/writing XML")]
+    XMLError(#[from] quick_xml::Error),
+
+    /// Error Deserializing internal 3MF XML structure
+    #[error("Deserialization error from xml reading")]
+    DeError(#[from] quick_xml::DeError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,14 @@
+use thiserror::Error;
+use zip::result::ZipError;
+
+/// An error that can occur while writing a 3MF file
+#[derive(Debug, Error)]
+pub enum Error {
+    /// I/O error while writing 3MF file
+    #[error("I/O error while importing/exporting to 3MF file")]
+    Io(#[from] std::io::Error),
+
+    /// Error writing ZIP file (3MF files are ZIP files)
+    #[error("Error writing ZIP file (3MF files are ZIP files)")]
+    Zip(#[from] ZipError),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,7 @@
 //! [Open Packaging Conventions]: https://standards.iso.org/ittf/PubliclyAvailableStandards/c061796_ISO_IEC_29500-2_2012.zip
 
 pub mod error;
+pub mod model;
 pub mod write;
 
-pub use self::{
-    mesh::TriangleMesh,
-    write::{write, Error},
-};
+pub use self::{error::Error, model::Mesh, write::write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! [3MF specification]: https://3mf.io/specification/
 //! [Open Packaging Conventions]: https://standards.iso.org/ittf/PubliclyAvailableStandards/c061796_ISO_IEC_29500-2_2012.zip
 
-pub mod mesh;
+pub mod error;
 pub mod write;
 
 pub use self::{

--- a/src/model-footer.xml
+++ b/src/model-footer.xml
@@ -1,7 +1,0 @@
-            </mesh>
-        </object>
-    </resources>
-    <build>
-        <item objectid="1" />
-    </build>
-</model>

--- a/src/model-header.xml
+++ b/src/model-header.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<model
-    xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
-    unit="millimeter"
-    xml:lang="en-US">
-
-    <resources>
-        <object id="1">
-            <mesh>

--- a/src/model/mesh.rs
+++ b/src/model/mesh.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// A triangle mesh
 ///
 /// This is a very basic types that lacks any amenities for constructing it or
@@ -7,32 +9,56 @@
 /// mesh type is out of scope for this library. It is expected that users of
 /// this library will use their own mesh type anyway, and the simplicity of
 /// `TriangleMesh` provides an easy target for conversion from such a type.
-pub struct TriangleMesh {
+#[derive(Serialize, Deserialize)]
+pub struct Mesh {
     /// The vertices of the mesh
     ///
     /// This defines the vertices that are part of the mesh, but not the mesh's
     /// structure. See the `triangles` field.
-    pub vertices: Vec<Vertex>,
+    pub vertices: Vertices,
 
     /// The triangles that make up the mesh
     ///
     /// Each triangle consists of indices that refer back to the `vertices`
     /// field.
-    pub triangles: Vec<IndexTriangle>,
+    pub triangles: Triangles,
+}
+
+/// A list of vertices, as a struct mainly to comply with easier serde xml
+#[derive(Serialize, Deserialize)]
+pub struct Vertices {
+    #[serde(default)]
+    pub vertex: Vec<Vertex>,
+}
+
+/// A list of triangles, as a struct mainly to comply with easier serde xml
+#[derive(Serialize, Deserialize)]
+pub struct Triangles {
+    #[serde(default)]
+    pub triangle: Vec<Triangle>,
 }
 
 /// A vertex in a triangle mesh
-///
-/// See [`TriangleMesh`].
-pub type Vertex = [f64; 3];
+#[derive(Serialize, Deserialize)]
+pub struct Vertex {
+    #[serde(rename = "@x")]
+    pub x: f64,
+    #[serde(rename = "@y")]
+    pub y: f64,
+    #[serde(rename = "@z")]
+    pub z: f64,
+}
 
 /// A triangle in a triangle mesh
 ///
 /// The triangle consists of indices that refer to the vertices of the mesh. See
 /// [`TriangleMesh`].
-pub type IndexTriangle = [Index; 3];
-
-/// An index that refers to a vertex in a triangle mesh
-///
-/// See [`TriangleMesh`] and [`IndexTriangle`].
-pub type Index = usize;
+#[derive(Serialize, Deserialize)]
+pub struct Triangle {
+    #[serde(rename = "@v1")]
+    pub v1: usize,
+    #[serde(rename = "@v2")]
+    pub v2: usize,
+    #[serde(rename = "@v3")]
+    pub v3: usize,
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,0 +1,106 @@
+pub mod mesh;
+pub use mesh::*;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct Model {
+    #[serde(rename = "@xmlns", default)]
+    pub xmlns: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+    pub resources: Resources,
+    pub build: Build,
+    #[serde(rename = "@unit", default)]
+    pub unit: Unit,
+}
+
+/// Model measurement unit, default is millimeter
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Unit {
+    Micron,
+    Millimeter,
+    Centimeter,
+    Inch,
+    Foot,
+    Meter,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Metadata {
+    #[serde(rename = "@name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Resources {
+    #[serde(default)]
+    pub object: Vec<Object>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub basematerials: Option<()>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct Object {
+    #[serde(rename = "@id")]
+    pub id: usize,
+    #[serde(rename = "@partnumber", skip_serializing_if = "Option::is_none")]
+    pub partnumber: Option<String>,
+    #[serde(rename = "@name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "@pid", skip_serializing_if = "Option::is_none")]
+    pub pid: Option<usize>,
+    #[serde(rename = "$value")]
+    pub object: ObjectData,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ObjectData {
+    Mesh(Mesh),
+    Components { component: Vec<Component> },
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Component {
+    #[serde(rename = "@objectid")]
+    pub objectid: usize,
+    #[serde(rename = "@transform", skip_serializing_if = "Option::is_none")]
+    pub transform: Option<[f64; 12]>,
+}
+#[derive(Serialize, Deserialize, Default)]
+pub struct Build {
+    #[serde(default)]
+    pub item: Vec<Item>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Item {
+    #[serde(rename = "@objectid")]
+    pub objectid: usize,
+    #[serde(rename = "@transform", skip_serializing_if = "Option::is_none")]
+    pub transform: Option<[f64; 12]>,
+    #[serde(rename = "@partnumber", skip_serializing_if = "Option::is_none")]
+    pub partnumber: Option<String>,
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Self {
+            xmlns: "http://schemas.microsoft.com/3dmanufacturing/core/2015/02".to_owned(),
+            metadata: Option::default(),
+            resources: Resources::default(),
+            build: Build::default(),
+            unit: Unit::default(),
+        }
+    }
+}
+
+impl Default for Unit {
+    fn default() -> Self {
+        Self::Millimeter
+    }
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,13 +5,22 @@ use std::{
 };
 
 use crate::Error;
+use quick_xml::{
+    events::{BytesDecl, Event},
+    se::Serializer,
+    Writer,
+};
+use serde::Serialize;
 
 use zip::{write::FileOptions, ZipWriter};
 
-use crate::TriangleMesh;
+use crate::{
+    model::{Build, Item, Model, Object, ObjectData, Resources},
+    Mesh,
+};
 
 /// Write a triangle mesh to a 3MF file
-pub fn write(path: &Path, mesh: &TriangleMesh) -> Result<(), Error> {
+pub fn write(path: &Path, mesh: Mesh) -> Result<(), Error> {
     let file = File::create(path)?;
     let mut archive = ZipWriter::new(file);
 
@@ -29,30 +38,40 @@ pub fn write(path: &Path, mesh: &TriangleMesh) -> Result<(), Error> {
     Ok(())
 }
 
-fn write_mesh(mut sink: impl Write, mesh: &TriangleMesh) -> io::Result<()> {
-    sink.write_all(include_bytes!("model-header.xml"))?;
+fn write_mesh(sink: impl Write, mesh: Mesh) -> Result<(), Error> {
+    let object = Object {
+        id: 1,
+        partnumber: None,
+        name: None,
+        pid: None,
+        object: ObjectData::Mesh(mesh),
+    };
+    let resources = Resources {
+        object: vec![object],
+        basematerials: None,
+    };
+    let build = Build {
+        item: vec![Item {
+            objectid: 1,
+            transform: None,
+            partnumber: None,
+        }],
+    };
+    let model = Model {
+        resources,
+        build,
+        ..Default::default()
+    };
 
-    writeln!(sink, "\t\t\t\t<vertices>")?;
-    for vertex in &mesh.vertices {
-        writeln!(
-            sink,
-            "\t\t\t\t\t<vertex x=\"{}\" y=\"{}\" z=\"{}\" />",
-            vertex[0], vertex[1], vertex[2],
-        )?;
-    }
-    writeln!(sink, "\t\t\t\t</vertices>")?;
+    let mut ser = Serializer::with_root(String::new(), Some("model"))?;
+    ser.indent(' ', 2);
 
-    writeln!(sink, "\t\t\t\t<triangles>")?;
-    for [i1, i2, i3] in &mesh.triangles {
-        writeln!(
-            sink,
-            "\t\t\t\t\t<triangle v1=\"{}\" v2=\"{}\" v3=\"{}\" />",
-            i1, i2, i3,
-        )?;
-    }
-    writeln!(sink, "\t\t\t\t</triangles>")?;
-
-    sink.write_all(include_bytes!("model-footer.xml"))?;
+    let mut xml_writer = Writer::new_with_indent(sink, b' ', 2);
+    xml_writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("utf-8"), None)))?;
+    xml_writer.write_indent()?;
+    xml_writer
+        .inner()
+        .write_all(model.serialize(ser).unwrap().as_bytes())?;
 
     Ok(())
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -4,9 +4,9 @@ use std::{
     path::Path,
 };
 
-use thiserror::Error;
+use crate::Error;
 
-use zip::{result::ZipError, write::FileOptions, ZipWriter};
+use zip::{write::FileOptions, ZipWriter};
 
 use crate::TriangleMesh;
 
@@ -55,16 +55,4 @@ fn write_mesh(mut sink: impl Write, mesh: &TriangleMesh) -> io::Result<()> {
     sink.write_all(include_bytes!("model-footer.xml"))?;
 
     Ok(())
-}
-
-/// An error that can occur while writing a 3MF file
-#[derive(Debug, Error)]
-pub enum Error {
-    /// I/O error while writing 3MF file
-    #[error("I/O error while exporting to 3MF file")]
-    Io(#[from] io::Error),
-
-    /// Error writing ZIP file (3MF files are ZIP files)
-    #[error("Error writing ZIP file (3MF files are ZIP files)")]
-    Zip(#[from] ZipError),
 }

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,0 +1,15 @@
+use threemf::model::ObjectData;
+
+#[test]
+fn test_object() {
+    let object_str = r#"<components><component objectid="66" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /><component objectid="67" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /><component objectid="68" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /></components>"#;
+    let object_de: ObjectData = quick_xml::de::from_str(object_str).unwrap();
+    match object_de {
+        ObjectData::Mesh(_) => panic!("No mesh in this object"),
+        ObjectData::Components { component } => {
+            assert_eq!(component.len(), 3);
+            let transform = component.first().unwrap().transform.unwrap();
+            assert_eq!(transform[0], 0.0393701);
+        }
+    }
+}

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,0 +1,41 @@
+use model::{Triangle, Triangles, Vertex, Vertices};
+use std::path::Path;
+use threemf::{model, Mesh};
+
+#[test]
+fn test_write() {
+    let vertices = Vertices {
+        vertex: vec![
+            Vertex {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            Vertex {
+                x: 0.0,
+                y: 2.0,
+                z: 0.0,
+            },
+            Vertex {
+                x: 0.0,
+                y: 1.0,
+                z: 1.0,
+            },
+        ],
+    };
+
+    let triangles = Triangles {
+        triangle: vec![Triangle {
+            v1: 0,
+            v2: 1,
+            v3: 2,
+        }],
+    };
+
+    let mesh = Mesh {
+        triangles,
+        vertices,
+    };
+
+    threemf::write(Path::new("triangle.3mf"), mesh).expect("Error writing mesh");
+}


### PR DESCRIPTION
_I was looking for some Rust-based parser for the 3mf structure and found this repo, so I thought I'd contribute some code that would otherwise be used locally. I have a future MR for some basic reading of the 3mf format, which builds on this branch._

---

This MR proposes the usage of serde for writing (future reading) of the 3mf Model XML.

Some steps have been taken to ensure that the serialization fits the overall structure that was there prior to this. Not all of these changes are "beautiful", but most are necessary to be able to re-use the same boilerplate structs for writing & reading (see my `serde-read` branch for basic read support).

This still doesn't support much more of the 3mf spec, but it should be sufficient as to what was there prior to this MR.

Hope this addition doesn't stray too much from the path this repository was taking.