### PR TITLE
don't use `std::fs::File`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 # Cargo
 /target
 Cargo.lock
-triangle.3mf

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,6 +1,5 @@
 use serde::Deserialize;
-use std::io::BufReader;
-use std::{fs::File, path::Path};
+use std::io::{self, BufReader, Read};
 
 use quick_xml::de::Deserializer;
 use zip::ZipArchive;
@@ -8,10 +7,9 @@ use zip::ZipArchive;
 use crate::model::Model;
 use crate::Error;
 
-/// Read all models from a 3MF file
-pub fn read(path: &Path) -> Result<Vec<Model>, Error> {
-    let file = File::open(path)?;
-    let mut zip = ZipArchive::new(file)?;
+/// Read all models from a 3MF reader
+pub fn read<R: Read + io::Seek>(reader: R) -> Result<Vec<Model>, Error> {
+    let mut zip = ZipArchive::new(reader)?;
     let mut models = Vec::new();
 
     for i in 0..zip.len() {

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::prelude::*, path::Path};
+use std::io::{self, prelude::*};
 
 use crate::Error;
 use quick_xml::{
@@ -15,10 +15,9 @@ use crate::{
     Mesh,
 };
 
-/// Write a triangle mesh to a 3MF file
-pub fn write(path: &Path, mesh: Mesh) -> Result<(), Error> {
-    let file = File::create(path)?;
-    let mut archive = ZipWriter::new(file);
+/// Write a triangle mesh to a 3MF writer
+pub fn write<W: Write + io::Seek>(writer: W, mesh: Mesh) -> Result<(), Error> {
+    let mut archive = ZipWriter::new(writer);
 
     archive.start_file("[Content_Types].xml", FileOptions::default())?;
     archive.write_all(include_bytes!("content-types.xml"))?;

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,5 +1,5 @@
 use model::{Triangle, Triangles, Vertex, Vertices};
-use std::path::Path;
+use std::io::Cursor;
 use threemf::{
     model::{self, ObjectData},
     Mesh,
@@ -42,8 +42,10 @@ fn roundtrip() {
 
     let write_mesh = mesh.clone();
 
-    threemf::write(Path::new("triangle.3mf"), mesh).expect("Error writing mesh");
-    let models = threemf::read(Path::new("triangle.3mf")).expect("Error reading model");
+    let mut buf = Cursor::new(Vec::new());
+
+    threemf::write(&mut buf, mesh).expect("Error writing mesh");
+    let models = threemf::read(&mut buf).expect("Error reading model");
 
     if let ObjectData::Mesh(read_mesh) = &models[0].resources.object[0].object {
         assert!(read_mesh == &write_mesh);


### PR DESCRIPTION
Closes #21 

One could argue that having a convenience function that takes a path and writes the model to the given path might be useful..
But since creating a file is one LOC I believe such a function would be of little use