### PR TITLE
Support metadatagroup in object

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -55,15 +55,17 @@ pub struct Object {
     pub name: Option<String>,
     #[serde(rename = "@pid", skip_serializing_if = "Option::is_none")]
     pub pid: Option<usize>,
-    #[serde(rename = "$value")]
-    pub object: ObjectData,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mesh: Option<Mesh>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Components>,
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ObjectData {
-    Mesh(Mesh),
-    Components { component: Vec<Component> },
+pub struct Components {
+    pub component: Vec<Component>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -114,7 +116,8 @@ impl From<Mesh> for Model {
             partnumber: None,
             name: None,
             pid: None,
-            object: ObjectData::Mesh(mesh),
+            mesh: Some(mesh),
+            components: None,
         };
         let resources = Resources {
             object: vec![object],

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,15 +1,42 @@
-use threemf::model::ObjectData;
+use threemf::model::{Components, Object};
 
 #[test]
 fn test_object() {
-    let object_str = r#"<components><component objectid="66" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /><component objectid="67" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /><component objectid="68" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /></components>"#;
-    let object_de: ObjectData = quick_xml::de::from_str(object_str).unwrap();
+    let object_str = r##"<object id="1"><components><component objectid="66" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /><component objectid="67" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /><component objectid="68" transform="0.0393701 0 0 0 0.0393701 0 0 0 0.0393701 0 0 0" /></components></object>"##;
+    let object_de: Object = quick_xml::de::from_str(object_str).unwrap();
     match object_de {
-        ObjectData::Mesh(_) => panic!("No mesh in this object"),
-        ObjectData::Components { component } => {
+        Object { mesh: Some(_), .. } => panic!("No mesh in this object"),
+        Object {
+            components: Some(Components { component }),
+            ..
+        } => {
             assert_eq!(component.len(), 3);
             let transform = component.first().unwrap().transform.unwrap();
             assert_eq!(transform[0], 0.0393701);
         }
+        _ => panic!("There should be components"),
     }
+}
+
+#[test]
+fn test_metadatagroup() {
+    let object_str = r##"
+                <object id="2" name="Part 2" type="model" p:UUID="5690f40c-430c-479f-b804-29081051c247" pid="1" pindex="0">
+                        <metadatagroup>
+                                <metadata name="customXMLNS0:PTC_onshape_metadata" type="entity_type">Body</metadata>
+                        </metadatagroup>
+                        <mesh>
+                                <vertices>
+                                        <vertex x="0.14470075" y="-0.02387521" z="-0.09085463" />
+                                        <vertex x="0.14421695" y="-0.02435900" z="-0.09359834" />
+                                        <vertex x="0.14147323" y="-0.02387521" z="-0.09085463" />
+                                </vertices>
+                                <triangles>
+                                        <triangle v1="0" v2="1" v3="2" />
+                                </triangles>
+                        </mesh>
+                </object>
+        "##;
+    let object_de: Object = quick_xml::de::from_str(object_str).unwrap();
+    assert!(object_de.mesh.is_some());
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,9 +1,6 @@
 use model::{Triangle, Triangles, Vertex, Vertices};
 use std::io::Cursor;
-use threemf::{
-    model::{self, ObjectData},
-    Mesh,
-};
+use threemf::{model, Mesh};
 
 #[test]
 fn roundtrip() {
@@ -47,7 +44,7 @@ fn roundtrip() {
     threemf::write(&mut buf, mesh).expect("Error writing mesh");
     let models = threemf::read(&mut buf).expect("Error reading model");
 
-    if let ObjectData::Mesh(read_mesh) = &models[0].resources.object[0].object {
+    if let Some(read_mesh) = &models[0].resources.object[0].mesh {
         assert!(read_mesh == &write_mesh);
     }
 }


### PR DESCRIPTION
This changes the model to support cases where an `<object>` tag includes a `<metadatagroup>` in addition to a `<mesh>`.

[Here's an example of this situation](https://github.com/3MFConsortium/spec_core/blob/master/3MF%20Core%20Specification.md#appendix-b2-3mf-metadata-example) from the official 3mf specs.

`ObjectData` can no longer be an enum, and needs to be merged into its `Object` parent.

The result is a breaking change.
