### PR TITLE
Bump quick-xml version due to security vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/hannobraun/3mf-rs"
 
 
 [dependencies]
-quick-xml = { version = "0.40.0", features = ["serialize"] }
+quick-xml = { version = "0.41.0", features = ["serialize"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "2.0.3"
 


### PR DESCRIPTION
Just a simple PR to bump the version of quick-xml from 0.40.0 to 0.41.0. There is a vulnerability in the old version and it may not be exploitable through threemf, but it will flag in CI for many people.

[Advisory](https://rustsec.org/packages/quick-xml.html)